### PR TITLE
Add example and help for `gum log --time` option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,12 @@ gum log --structured --level debug "Creating file..." name file.txt
 # Log some error.
 gum log --structured --level error "Unable to create file." name file.txt
 # ERROR Unable to create file. name=temp.txt
+
+# Include a timestamp.
+gum log --time rfc822 --level error "Unable to create file."
 ```
+
+The `--time` option accepts any constant defined in [the Go `time` package](https://pkg.go.dev/time#pkg-constants), case-insensitively. 
 
 See [`charmbracelet/log`](https://github.com/charmbracelet/log) for more usage.
 


### PR DESCRIPTION
The `gum log --help` output for `--time` option says

```
-t, --time=""             The time format to use (kitchen, layout, ansic, rfc822, etc...)
```

with no indication of what `etc...` means. This is probably inferred for proficient Go programmers, but not for everyone else.

This commit makes it clearer which options are supported by `--time` by linking to the docs for the `time` library,

Fixes #...

### Changes
- 
- 
-
